### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A comprehensive Model Context Protocol (MCP) server for rekordbox database manag
 
 **Built using [pyrekordbox](https://github.com/dylanljones/pyrekordbox)** - This project is not affiliated with the pyrekordbox project or its maintainers.
 
+<a href="https://glama.ai/mcp/servers/@davehenke/rekordbox-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@davehenke/rekordbox-mcp/badge" alt="rekordbox-mcp MCP server" />
+</a>
+
 ## Features
 
 ### 🗄️ Database Access


### PR DESCRIPTION
This PR adds a badge for the [rekordbox-mcp](https://glama.ai/mcp/servers/@davehenke/rekordbox-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@davehenke/rekordbox-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@davehenke/rekordbox-mcp/badge" alt="rekordbox-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.